### PR TITLE
Fix broken sysctl() calls on FreeBSD (64-bit)

### DIFF
--- a/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
@@ -16,8 +16,8 @@ extern float external_bogomips(void);
 
 int get_cpu_info(struct cpu_info_type *cpu_info) {
 
-   int val_int;
-   int val_len;
+   size_t val_int = 0;
+   size_t val_len = 0;
 
    char val_str[BUFSIZ];
 

--- a/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/cpuinfo_bsd.c
@@ -16,8 +16,8 @@ extern float external_bogomips(void);
 
 int get_cpu_info(struct cpu_info_type *cpu_info) {
 
-   size_t val_int = 0;
-   size_t val_len = 0;
+   size_t val_int=0;
+   size_t val_len=0;
 
    char val_str[BUFSIZ];
 

--- a/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
@@ -88,8 +88,8 @@ long long get_mem_size(void) {
     int ctl_ram[] = { CTL_HW, HW_PHYSMEM };
     long long mem_size=0;
 
-    size_t val_int;
-    size_t val_len;
+    size_t val_int=0;
+    size_t val_len=0;
    
     val_len = sizeof(val_int);
     if (sysctl(ctl_ram, SIZE(ctl_ram), &val_int, &val_len,0,0))

--- a/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
+++ b/libsysinfo-0.2.2/FreeBSD/sysinfo_bsd.c
@@ -88,8 +88,8 @@ long long get_mem_size(void) {
     int ctl_ram[] = { CTL_HW, HW_PHYSMEM };
     long long mem_size=0;
 
-    int val_int;
-    int val_len;
+    size_t val_int;
+    size_t val_len;
    
     val_len = sizeof(val_int);
     if (sysctl(ctl_ram, SIZE(ctl_ram), &val_int, &val_len,0,0))


### PR DESCRIPTION
Upstream issue #4.
